### PR TITLE
Add the aliases to clang from the manual setup to the Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,9 @@ ENV WASI_SDK_VERSION=14.0
 RUN cd /opt && curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-14/wasi-sdk-${WASI_SDK_VERSION}-linux.tar.gz \
     | tar -xz
 
+RUN echo 'alias clang=/opt/wasi-sdk-14.0/bin/clang' >> /etc/bash.bashrc
+RUN echo 'alias clang++=/opt/wasi-sdk-14.0/bin/clang++' >> /etc/bash.bashrc
+
 ENV WASMTIME_VERSION=0.33.0
 RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz \ 
     | tar -xJ --wildcards --no-anchored --strip-components 1 -C /usr/bin wasmtime


### PR DESCRIPTION
When users go through our tutorial, we instruct them to use the DevContainer but it does not actually include the aliases we define in the manual setup and assume are present in the following sections. This PR adds two lines to the DevContainer Dockerfile to add those aliases so they are available with both setups.